### PR TITLE
fix: update to latest typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "clean": "rimraf ./dist",
     "clean:example": "rimraf ./example-project/dist",
     "clean:plugin": "rimraf  node_modules/typedoc-plugin-markdown-pages",
-	"copy:plugin": "copyfiles package.json ./dist/**/* node_modules/typedoc-plugin-markdown-pages/",
-	"copy:theme": "copyfiles ./src/theme/**/* ./dist/theme/ -u 2",
+    "copy:plugin": "copyfiles package.json ./dist/**/* node_modules/typedoc-plugin-markdown-pages/",
+    "copy:theme": "copyfiles ./src/theme/**/* ./dist/theme/ -u 2",
     "example": "npm run build && npm run prepare:plugin && npm run build:example",
     "prepare:plugin": "npm run clean:plugin && npm run copy:plugin",
     "test:unit": "mocha -r ts-node/register test/**/*.spec.ts",
-	"test:unit:cover": "nyc mocha -r ts-node/register -r source-map-support/register --recursive test/**/*.spec.ts",
-	"report-coverage": "codecov"
+    "test:unit:cover": "nyc mocha -r ts-node/register -r source-map-support/register --recursive test/**/*.spec.ts",
+    "report-coverage": "codecov"
   },
   "nyc": {
     "extension": [
@@ -63,8 +63,9 @@
     "source-map-support": "^0.5.12",
     "ts-node": "^8.0.3",
     "tslint": "^5.15.0",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.19.2",
     "typemoq": "^2.1.0",
-    "typescript": "^3.4.3"
+    "typescript": "^3.4.3",
+    "@types/node": "^14.14.8"
   }
 }

--- a/src/helpers/options-helper.ts
+++ b/src/helpers/options-helper.ts
@@ -1,5 +1,4 @@
 import { resolve } from "path";
-import { OptionsReadMode } from "typedoc/dist/lib/utils/options";
 import { Options } from "typedoc/dist/lib/utils/options";
 import { Application } from "typedoc/dist/lib/application";
 import { DEFAULT_OUTPUT_DIR_NAME, DEFAULT_PAGES_LABEL } from "../constants";
@@ -26,7 +25,7 @@ export class OptionsHelper {
 	 */
 	public get sourcePath(): string {
 		try {
-			const sourcePath = this._getOptions().getValue(SOURCE_PATH_OPTION.name);
+			const sourcePath = <string> this._getOptions().getValue(SOURCE_PATH_OPTION.name);
 			if (!sourcePath || sourcePath.length === 0) {
 				throw new Error("Pages source path must be specified.");
 			} else {
@@ -43,7 +42,7 @@ export class OptionsHelper {
 	 */
 	public get outputDirName(): string {
 		try {
-			const outputDirName = this._getOptions().getValue(OUTPUT_DIR_NAME_OPTION.name);
+			const outputDirName =  <string> this._getOptions().getValue(OUTPUT_DIR_NAME_OPTION.name);
 			if (!outputDirName || outputDirName.length === 0) {
 				return DEFAULT_OUTPUT_DIR_NAME;
 			} else {
@@ -59,7 +58,7 @@ export class OptionsHelper {
 	 * @readonly
 	 */
 	public get pagesLabel(): string {
-		const label = this._getOptions().getValue(LABEL_OPTION.name);
+		const label = <string> this._getOptions().getValue(LABEL_OPTION.name);
 		if (!label || label.length === 0) {
 			return DEFAULT_PAGES_LABEL;
 		} else {
@@ -91,6 +90,5 @@ export class OptionsHelper {
 	 */
 	private _readTypeDocOptions(): void {
 		this._options = this._application.options;
-		this._options.read({}, OptionsReadMode.Prefetch);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ module.exports = (PluginHost: Application): void => {
 	const app = PluginHost.owner;
 
 	// Register options
-	app.options.addDeclaration(LABEL_OPTION);
-	app.options.addDeclaration(OUTPUT_DIR_NAME_OPTION);
-	app.options.addDeclaration(SOURCE_PATH_OPTION);
+	app.options.addDeclaration(<any> LABEL_OPTION);
+	app.options.addDeclaration(<any> OUTPUT_DIR_NAME_OPTION);
+	app.options.addDeclaration(<any> SOURCE_PATH_OPTION);
 
 	// Register components
 	app.renderer.addComponent(PLUGIN_NAME, new MarkdownPagesPlugin(app.renderer));

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,23 +1,19 @@
-import { OptionDeclaration, ParameterType } from "typedoc/dist/lib/utils/options/declaration";
-import { PLUGIN_NAME } from "./constants";
+import { ParameterType, DeclarationOptionBase } from "typedoc/dist/lib/utils/options/declaration";
 
-export const LABEL_OPTION = new OptionDeclaration({
-	component: PLUGIN_NAME,
+export const LABEL_OPTION : DeclarationOptionBase = {
 	help: "Markdown Pages Plugin: The navigation label for markdown pages.",
 	name: "mdPagesLabel",
 	type: ParameterType.String,
-});
+};
 
-export const OUTPUT_DIR_NAME_OPTION = new OptionDeclaration({
-	component: PLUGIN_NAME,
+export const OUTPUT_DIR_NAME_OPTION : DeclarationOptionBase ={
 	help: "Markdown Pages Plugin: The name of the directory pages will be output to",
 	name: "mdPagesOutputDirName",
 	type: ParameterType.String,
-});
+};
 
-export const SOURCE_PATH_OPTION = new OptionDeclaration({
-	component: PLUGIN_NAME,
+export const SOURCE_PATH_OPTION : DeclarationOptionBase = {
 	help: "Markdown Pages Plugin: The path to the directory where pages will be read from",
 	name: "mdPagesSourcePath",
 	type: ParameterType.String,
-});
+};


### PR DESCRIPTION
Upgrade to latest typedoc and fix the compilation error. It seems the class disappeared to just an interface.

It seems you were pretty busy, is there any hope to get it into a release? As I'd like to use this into the doc but without release, I will have to do a duplicated package which is not something I like